### PR TITLE
Use ExceptionMapper to put entity into response

### DIFF
--- a/src/main/java/org/eclipse/microprofile/ft/serviceb/ServiceBEndpoint.java
+++ b/src/main/java/org/eclipse/microprofile/ft/serviceb/ServiceBEndpoint.java
@@ -43,13 +43,13 @@ public class ServiceBEndpoint {
         count++;
         
         if ((count %10 >3) && (count %10 <7)){
-        	//x4, x5, x6 will succeed
-        	return "I'm happy from Service B. Invocation count: " + count;
+            //x4, x5, x6 will succeed
+            return "I'm happy from Service B. Invocation count: " + count;
         } else if (count % 10 >=7 ) {
-        	Thread.sleep(5000);//sleep for 8s
+            Thread.sleep(5000);//sleep for 8s
             return "I'm happy from Service B. Invocation count:" + count;
         } else {
-        	throw new Exception("I'm tired! Invocation count" + count);
+            throw new TiredException("I'm tired! Invocation count" + count);
         }
         
     }

--- a/src/main/java/org/eclipse/microprofile/ft/serviceb/TiredException.java
+++ b/src/main/java/org/eclipse/microprofile/ft/serviceb/TiredException.java
@@ -1,0 +1,30 @@
+package org.eclipse.microprofile.ft.serviceb;
+
+public class TiredException extends Exception {
+    private static final long serialVersionUID = 486037584567764149L;
+
+    public TiredException() {
+        // TODO Auto-generated constructor stub
+    }
+
+    public TiredException(String message) {
+        super(message);
+        // TODO Auto-generated constructor stub
+    }
+
+    public TiredException(Throwable cause) {
+        super(cause);
+        // TODO Auto-generated constructor stub
+    }
+
+    public TiredException(String message, Throwable cause) {
+        super(message, cause);
+        // TODO Auto-generated constructor stub
+    }
+
+    public TiredException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        // TODO Auto-generated constructor stub
+    }
+
+}

--- a/src/main/java/org/eclipse/microprofile/ft/serviceb/TiredExceptionMapper.java
+++ b/src/main/java/org/eclipse/microprofile/ft/serviceb/TiredExceptionMapper.java
@@ -1,0 +1,17 @@
+package org.eclipse.microprofile.ft.serviceb;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class TiredExceptionMapper implements ExceptionMapper<TiredException> {
+
+    @Override
+    public Response toResponse(TiredException ex) {
+        return Response.status(500)
+                       .entity(ex.getMessage())
+                       .build();
+    }
+
+}


### PR DESCRIPTION
Per conversation with @Emily-Jiang - this change will ensure that the response sent back to the client contains the exception text - "I'm tired! Invocation count" + counter.

